### PR TITLE
Fix parameter structure in Bing API spec

### DIFF
--- a/API_actions/bing_requests.txt
+++ b/API_actions/bing_requests.txt
@@ -23,6 +23,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: cc
+          in: query
+          x-ms-parameter-location: client
+          description: The market where results come from, by default is GLOBAL
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: A JSON response with search results and relevant HTTP headers
@@ -32,13 +39,6 @@ paths:
                 $ref: '#/components/schemas/searchResponse'
       security:
         - OcpApimSubscriptionKey: []
-      x-ms-parameter-location:
-        name: cc
-        x-ms-parameter-location: "client"
-        description: The market where results come from, by default is GLOBAL
-        required: false
-        schema:
-          type: string
   /v7.0/news/search:
     get:
       operationId: searchNews
@@ -51,6 +51,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: cc
+          in: query
+          x-ms-parameter-location: client
+          description: The market where results come from, by default is GLOBAL
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: A JSON response with news search results and relevant HTTP headers
@@ -60,13 +67,6 @@ paths:
                 $ref: '#/components/schemas/newsSearchResponse'
       security:
         - OcpApimSubscriptionKey: []
-      x-ms-parameter-location:
-        name: cc
-        x-ms-parameter-location: "client"
-        description: The market where results come from, by default is GLOBAL
-        required: false
-        schema:
-          type: string
 components:
   securitySchemes:
     OcpApimSubscriptionKey:


### PR DESCRIPTION
## Summary
- fix `bing_requests.txt` parameter lists so the `cc` query parameter is properly included

## Testing
- `pytest -q`

